### PR TITLE
Show and log api errors.

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -247,4 +247,12 @@ router
                 });
             }
         });
+    })
+
+    .use(function(err, req, res, next){
+        if (err) {
+            console.log(err);
+            res.status(500);
+            res[req.rt]({ error: err });
+        }
     });


### PR DESCRIPTION
Just what it says, show any api errors that might occur. Encountered this when i had a google analytics api error and the only thing shown was [Object Object] and it might help others debug their own issues.
Thank you for making this available by the way, really useful.